### PR TITLE
Added inclusion of numpy dirs so that headers like 'arrayobject.h' can import

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ import tempfile
 
 # Third-Party Libraries
 import setuptools
+import numpy as np
 
 # TODO: to build the library, numpy headers (arrayobject.h for example)
 #       are needed, handle that. When setuptools is "playing" with bitstream,
@@ -30,6 +31,7 @@ metadata = dict(
   author = u"Sébastien Boisgérault",
   author_email = "Sebastien.Boisgerault@mines-paristech.fr",
   license = "MIT License",
+  include_dirs = [np.get_include()],
   classifiers = [
     "Development Status :: 3 - Alpha",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
If you look at line 18, this is the beginning of the @TODO I believe.

Not sure if you want this added, but now I can install this on MAC OSX with pip (originally I couldnt because it couldnt import the arrayobject.h module with cython.

Merci pour ce module!
