### PR TITLE
Added "include_dirs" argument to cythonize

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ def make_extension():
         require("Cython", "0.15.1")
         import Cython
         from Cython.Build import cythonize
-        return cythonize("bitstream.pyx")
+        return cythonize("bitstream.pyx", include_dirs=[numpy.get_include()])
     else:
         if os.path.exists("bitstream.c"):
             return [setuptools.Extension("bitstream", 


### PR DESCRIPTION
Added "include_dirs" argument to cythonize in order to locate numpy headers when installing with the option --cython.
Before the fix, the install failed with an error saying that numpy/arrayobject.h was not found.
